### PR TITLE
Add support for SHA-384 and SHA-512 hash algorithms for ClickOnce apps

### DIFF
--- a/src/Tasks/ManifestUtil/RSAPKCS1SHA384SignatureDescription.cs
+++ b/src/Tasks/ManifestUtil/RSAPKCS1SHA384SignatureDescription.cs
@@ -1,0 +1,51 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Security.Cryptography;
+
+#nullable disable
+
+namespace System.Deployment.Internal.CodeSigning
+{
+    [SuppressMessage("Microsoft.Naming", "CA1709:IdentifiersShouldBeCasedCorrectly", MessageId = "RSAPKCS", Justification = "This casing is to match the existing RSAPKCS1SHA256SignatureDescription type")]
+    [SuppressMessage("Microsoft.Naming", "CA1709:IdentifiersShouldBeCasedCorrectly", MessageId = "SHA", Justification = "This casing is to match the use of SHA throughout the framework")]
+    public sealed class RSAPKCS1SHA384SignatureDescription : SignatureDescription
+    {
+        public RSAPKCS1SHA384SignatureDescription()
+        {
+            KeyAlgorithm = typeof(RSACryptoServiceProvider).FullName;
+#if RUNTIME_TYPE_NETCORE
+            DigestAlgorithm = typeof(SHA384).FullName;
+#else
+            DigestAlgorithm = typeof(SHA384Cng).FullName;
+#endif
+            FormatterAlgorithm = typeof(RSAPKCS1SignatureFormatter).FullName;
+            DeformatterAlgorithm = typeof(RSAPKCS1SignatureDeformatter).FullName;
+        }
+
+        public override AsymmetricSignatureDeformatter CreateDeformatter(AsymmetricAlgorithm key)
+        {
+            if (key == null)
+            {
+                throw new ArgumentNullException(nameof(key));
+            }
+
+            RSAPKCS1SignatureDeformatter deformatter = new RSAPKCS1SignatureDeformatter(key);
+            deformatter.SetHashAlgorithm("SHA384");
+            return deformatter;
+        }
+
+        public override AsymmetricSignatureFormatter CreateFormatter(AsymmetricAlgorithm key)
+        {
+            if (key == null)
+            {
+                throw new ArgumentNullException(nameof(key));
+            }
+
+            RSAPKCS1SignatureFormatter formatter = new RSAPKCS1SignatureFormatter(key);
+            formatter.SetHashAlgorithm("SHA384");
+            return formatter;
+        }
+    }
+}

--- a/src/Tasks/ManifestUtil/RSAPKCS1SHA512SignatureDescription.cs
+++ b/src/Tasks/ManifestUtil/RSAPKCS1SHA512SignatureDescription.cs
@@ -1,0 +1,51 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Security.Cryptography;
+
+#nullable disable
+
+namespace System.Deployment.Internal.CodeSigning
+{
+    [SuppressMessage("Microsoft.Naming", "CA1709:IdentifiersShouldBeCasedCorrectly", MessageId = "RSAPKCS", Justification = "This casing is to match the existing RSAPKCS1SHA1SignatureDescription type")]
+    [SuppressMessage("Microsoft.Naming", "CA1709:IdentifiersShouldBeCasedCorrectly", MessageId = "SHA", Justification = "This casing is to match the use of SHA throughout the framework")]
+    public sealed class RSAPKCS1SHA512SignatureDescription : SignatureDescription
+    {
+        public RSAPKCS1SHA512SignatureDescription()
+        {
+            KeyAlgorithm = typeof(RSACryptoServiceProvider).FullName;
+#if RUNTIME_TYPE_NETCORE
+            DigestAlgorithm = typeof(SHA512).FullName;
+#else
+            DigestAlgorithm = typeof(SHA512Cng).FullName;
+#endif
+            FormatterAlgorithm = typeof(RSAPKCS1SignatureFormatter).FullName;
+            DeformatterAlgorithm = typeof(RSAPKCS1SignatureDeformatter).FullName;
+        }
+
+        public override AsymmetricSignatureDeformatter CreateDeformatter(AsymmetricAlgorithm key)
+        {
+            if (key == null)
+            {
+                throw new ArgumentNullException(nameof(key));
+            }
+
+            RSAPKCS1SignatureDeformatter deformatter = new RSAPKCS1SignatureDeformatter(key);
+            deformatter.SetHashAlgorithm("SHA512");
+            return deformatter;
+        }
+
+        public override AsymmetricSignatureFormatter CreateFormatter(AsymmetricAlgorithm key)
+        {
+            if (key == null)
+            {
+                throw new ArgumentNullException(nameof(key));
+            }
+
+            RSAPKCS1SignatureFormatter formatter = new RSAPKCS1SignatureFormatter(key);
+            formatter.SetHashAlgorithm("SHA512");
+            return formatter;
+        }
+    }
+}

--- a/src/Tasks/ManifestUtil/SecurityUtil.cs
+++ b/src/Tasks/ManifestUtil/SecurityUtil.cs
@@ -578,19 +578,19 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
                     throw new ArgumentException("TargetFrameworkVersion");
                 }
 
-                bool isTargetFrameworkSha256Supported = false;
+                bool isTargetFrameworkSha256OrHigherSupported = false;
                 if (String.IsNullOrEmpty(targetFrameworkIdentifier) ||
                     targetFrameworkIdentifier.Equals(Constants.DotNetFrameworkIdentifier, StringComparison.InvariantCultureIgnoreCase))
                 {
                     // SHA-256 digest can be parsed only with .NET 4.5 or higher.
-                    isTargetFrameworkSha256Supported = targetVersion.CompareTo(s_dotNet45Version) >= 0;
+                    isTargetFrameworkSha256OrHigherSupported = targetVersion.CompareTo(s_dotNet45Version) >= 0;
                 }
                 else if (targetFrameworkIdentifier.Equals(Constants.DotNetCoreAppIdentifier, StringComparison.InvariantCultureIgnoreCase))
                 {
                     // Use SHA-256 digest for .NET Core apps
-                    isTargetFrameworkSha256Supported = true;
+                    isTargetFrameworkSha256OrHigherSupported = true;
                 }
-                SignFileInternal(cert, timestampUrl, path, isTargetFrameworkSha256Supported, resources, disallowMansignTimestampFallback);
+                SignFileInternal(cert, timestampUrl, path, isTargetFrameworkSha256OrHigherSupported, resources, disallowMansignTimestampFallback);
             }
             else
             {
@@ -614,14 +614,12 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
             SignFile(cert, timestampUrl, path);
         }
 
-        private static bool UseSha256Algorithm(X509Certificate2 cert)
+        private static bool UseSha256OrHigherAlgorithm(X509Certificate2 cert)
         {
             Oid oid = cert.SignatureAlgorithm;
-            // Issue 6732: Clickonce does not support sha384/sha512 file hash so we default to sha256
-            // for certs with that signature algorithm.
-            return string.Equals(oid.FriendlyName, "sha256RSA", StringComparison.OrdinalIgnoreCase) ||
-                   string.Equals(oid.FriendlyName, "sha384RSA", StringComparison.OrdinalIgnoreCase) ||
-                   string.Equals(oid.FriendlyName, "sha512RSA", StringComparison.OrdinalIgnoreCase);
+            return string.Equals(oid.Value, System.Deployment.Internal.CodeSigning.Win32.szOID_RSA_SHA256RSA, StringComparison.OrdinalIgnoreCase) ||
+                   string.Equals(oid.Value, System.Deployment.Internal.CodeSigning.Win32.szOID_RSA_SHA384RSA, StringComparison.OrdinalIgnoreCase) ||
+                   string.Equals(oid.Value, System.Deployment.Internal.CodeSigning.Win32.szOID_RSA_SHA512RSA, StringComparison.OrdinalIgnoreCase);
         }
 
         /// <summary>
@@ -637,14 +635,14 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
         {
             // setup resources
             System.Resources.ResourceManager resources = new System.Resources.ResourceManager("Microsoft.Build.Tasks.Core.Strings.ManifestUtilities", typeof(SecurityUtilities).Module.Assembly);
-            SignFileInternal(cert, timestampUrl, path, targetFrameworkSupportsSha256: true, resources);
+            SignFileInternal(cert, timestampUrl, path, targetFrameworkSupportsSha256OrHigher: true, resources);
         }
 
         [SupportedOSPlatform("windows")]
         private static void SignFileInternal(X509Certificate2 cert,
                                             Uri timestampUrl,
                                             string path,
-                                            bool targetFrameworkSupportsSha256,
+                                            bool targetFrameworkSupportsSha256OrHigher,
                                             System.Resources.ResourceManager resources,
                                             bool disallowMansignTimestampFallback = false)
         {
@@ -663,13 +661,13 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
                 throw new FileNotFoundException(String.Format(CultureInfo.InvariantCulture, resources.GetString("SecurityUtil.SignTargetNotFound"), path), path);
             }
 
-            bool useSha256 = UseSha256Algorithm(cert) && targetFrameworkSupportsSha256;
+            bool useSha256OrHigher = UseSha256OrHigherAlgorithm(cert) && targetFrameworkSupportsSha256OrHigher;
 
             if (PathUtil.IsPEFile(path))
             {
                 if (IsCertInStore(cert))
                 {
-                    SignPEFile(cert, timestampUrl, path, resources, useSha256);
+                    SignPEFile(cert, timestampUrl, path, resources, useSha256OrHigher);
                 }
                 else
                 {
@@ -702,17 +700,17 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
                             doc.Load(xr);
                         }
 
-                        var manifest = new SignedCmiManifest2(doc, useSha256);
+                        var manifest = new SignedCmiManifest2(doc, useSha256OrHigher);
                         CmiManifestSigner2 signer;
-                        if (useSha256 && rsa is RSACryptoServiceProvider rsacsp)
+                        if (useSha256OrHigher && rsa is RSACryptoServiceProvider rsacsp)
                         {
 #pragma warning disable CA2000 // Dispose objects before losing scope because CmiManifestSigner2 will dispose the RSACryptoServiceProvider
-                            signer = new CmiManifestSigner2(SignedCmiManifest2.GetFixedRSACryptoServiceProvider(rsacsp, useSha256), cert, useSha256);
+                            signer = new CmiManifestSigner2(SignedCmiManifest2.GetFixedRSACryptoServiceProvider(rsacsp, useSha256OrHigher), cert, useSha256OrHigher);
 #pragma warning restore CA2000 // Dispose objects before losing scope
                         }
                         else
                         {
-                            signer = new CmiManifestSigner2(rsa, cert, useSha256);
+                            signer = new CmiManifestSigner2(rsa, cert, useSha256OrHigher);
                         }
 
 #if RUNTIME_TYPE_NETCORE
@@ -764,27 +762,27 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
             }
         }
 
-        private static void SignPEFile(X509Certificate2 cert, Uri timestampUrl, string path, System.Resources.ResourceManager resources, bool useSha256)
+        private static void SignPEFile(X509Certificate2 cert, Uri timestampUrl, string path, System.Resources.ResourceManager resources, bool useSha256OrHigher)
         {
             try
             {
-                SignPEFileInternal(cert, timestampUrl, path, resources, useSha256, true);
+                SignPEFileInternal(cert, timestampUrl, path, resources, useSha256OrHigher, true);
             }
             catch (ApplicationException) when (timestampUrl != null)
             {
                 // error, retry with signtool /t if timestamp url was given
-                SignPEFileInternal(cert, timestampUrl, path, resources, useSha256, false);
+                SignPEFileInternal(cert, timestampUrl, path, resources, useSha256OrHigher, false);
                 return;
             }
         }
 
         private static void SignPEFileInternal(X509Certificate2 cert, Uri timestampUrl,
                                                string path, System.Resources.ResourceManager resources,
-                                               bool useSha256, bool useRFC3161Timestamp)
+                                               bool useSha256OrHigher, bool useRFC3161Timestamp)
         {
             var startInfo = new ProcessStartInfo(
                 GetPathToTool(resources),
-                GetCommandLineParameters(cert.Thumbprint, timestampUrl, path, useSha256, useRFC3161Timestamp))
+                GetCommandLineParameters(cert, timestampUrl, path, useSha256OrHigher, useRFC3161Timestamp))
             {
                 CreateNoWindow = true,
                 UseShellExecute = false,
@@ -825,17 +823,23 @@ namespace Microsoft.Build.Tasks.Deployment.ManifestUtilities
             }
         }
 
-        internal static string GetCommandLineParameters(string certThumbprint, Uri timestampUrl, string path,
-                                                        bool useSha256, bool useRFC3161Timestamp)
+        internal static string GetCommandLineParameters(X509Certificate2 cert, Uri timestampUrl, string path,
+                                                        bool useSha256OrHigher, bool useRFC3161Timestamp)
         {
-            var commandLine = new StringBuilder();
-            if (useSha256)
+            string hashAlgoName = ManifestSignatureUtility.GetHashAlgorithmName(cert);
+            if (string.IsNullOrEmpty(hashAlgoName))
             {
-                commandLine.AppendFormat(CultureInfo.InvariantCulture, "sign /fd sha256 /sha1 {0} ", certThumbprint);
+                throw new CryptographicException(System.Deployment.Internal.CodeSigning.Win32.CRYPT_E_UNKNOWN_ALGO);
+            }
+
+            var commandLine = new StringBuilder();
+            if (useSha256OrHigher)
+            {
+                commandLine.AppendFormat(CultureInfo.InvariantCulture, "sign /fd {0} /sha1 {1} ", hashAlgoName, cert.Thumbprint);
             }
             else
             {
-                commandLine.AppendFormat(CultureInfo.InvariantCulture, "sign /sha1 {0} ", certThumbprint);
+                commandLine.AppendFormat(CultureInfo.InvariantCulture, "sign /sha1 {0} ", cert.Thumbprint);
             }
 
             if (timestampUrl != null)

--- a/src/Tasks/ManifestUtil/mansign2.cs
+++ b/src/Tasks/ManifestUtil/mansign2.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Runtime.InteropServices;
@@ -60,6 +61,7 @@ namespace System.Deployment.Internal.CodeSigning
         internal const int TRUST_E_FAIL = unchecked((int)0x800B010B);
         internal const int TRUST_E_EXPLICIT_DISTRUST = unchecked((int)0x800B0111);
         internal const int CERT_E_CHAINING = unchecked((int)0x800B010A);
+        internal const int CRYPT_E_UNKNOWN_ALGO = unchecked((int)0x80091002);
 
         // Values for dwFlags of CertVerifyAuthenticodeLicense.
         internal const int AXL_REVOCATION_NO_CHECK = unchecked((int)0x00000001);
@@ -180,6 +182,11 @@ namespace System.Deployment.Internal.CodeSigning
         // hash algorithm OIDs
         internal const string szOID_OIWSEC_sha1 = "1.3.14.3.2.26";
         internal const string szOID_NIST_sha256 = "2.16.840.1.101.3.4.2.1";
+        internal const string szOID_sha384 = "2.16.840.1.101.3.4.2.2";
+        internal const string szOID_sha512 = "2.16.840.1.101.3.4.2.3";
+        internal const string szOID_RSA_SHA256RSA = "1.2.840.113549.1.1.11";
+        internal const string szOID_RSA_SHA384RSA = "1.2.840.113549.1.1.12";
+        internal const string szOID_RSA_SHA512RSA = "1.2.840.113549.1.1.13";
 
         [StructLayout(LayoutKind.Sequential)]
         internal struct CRYPT_TIMESTAMP_CONTEXT
@@ -235,11 +242,78 @@ namespace System.Deployment.Internal.CodeSigning
         internal static extern void CryptMemFree(IntPtr pv);
     }
 
+    internal class ManifestSignatureUtility
+    {
+        internal const string Sha1SignatureMethodUri = @"http://www.w3.org/2000/09/xmldsig#rsa-sha1";
+        internal const string Sha256SignatureMethodUri = @"http://www.w3.org/2000/09/xmldsig#rsa-sha256";
+        internal const string Sha384SignatureMethodUri = @"http://www.w3.org/2000/09/xmldsig#rsa-sha384";
+        internal const string Sha512SignatureMethodUri = @"http://www.w3.org/2000/09/xmldsig#rsa-sha512";
+        internal const string Sha256DigestMethod = @"http://www.w3.org/2000/09/xmldsig#sha256";
+        internal const string Sha384DigestMethod = @"http://www.w3.org/2000/09/xmldsig#sha384"; 
+        internal const string Sha512DigestMethod = @"http://www.w3.org/2000/09/xmldsig#sha512";
+        internal const string Sha1DigestMethod = @"http://www.w3.org/2000/09/xmldsig#sha1";
+
+#if FEATURE_CRYPTOGRAPHIC_FACTORY_ALGORITHM_NAMES
+        internal static readonly Dictionary<string, Func<string, HashAlgorithm>> SupportedHashAlgorithmsFactories
+            = new Dictionary<string, Func<string, HashAlgorithm>>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["SHA256"] = (algorithmName) => SHA256.Create("System.Security.Cryptography.SHA256CryptoServiceProvider"),
+            ["SHA384"] = (algorithmName) => SHA384.Create("System.Security.Cryptography.SHA384CryptoServiceProvider"),
+            ["SHA512"] = (algorithmName) => SHA512.Create("System.Security.Cryptography.SHA512CryptoServiceProvider"),
+        };
+#else
+        internal static readonly Dictionary<string, Func<HashAlgorithm>> SupportedHashAlgorithmsFactories
+            = new Dictionary<string, Func<HashAlgorithm>>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["SHA256"] = () => SHA256.Create(),
+            ["SHA384"] = () => SHA384.Create(),
+            ["SHA512"] = () => SHA512.Create(),
+        };
+#endif
+
+#if FEATURE_CRYPTOGRAPHIC_FACTORY_ALGORITHM_NAMES
+        internal static Func<string, HashAlgorithm> GetHashAlgorithmFactory(X509Certificate2 cert)
+#else
+        internal static Func<HashAlgorithm> GetHashAlgorithmFactory(X509Certificate2 cert)
+#endif
+        {
+            string algoName = GetHashAlgorithmName(cert);
+            return SupportedHashAlgorithmsFactories.TryGetValue(algoName, out var algorithmFactory)
+                ? algorithmFactory
+                : null;
+        }
+
+        internal static string GetHashAlgorithmName(X509Certificate2 cert)
+        {
+            Oid oid = cert.SignatureAlgorithm;
+            if (string.Equals(oid.Value, Win32.szOID_RSA_SHA256RSA, StringComparison.OrdinalIgnoreCase)) { return "sha256"; }
+            if (string.Equals(oid.Value, Win32.szOID_RSA_SHA384RSA, StringComparison.OrdinalIgnoreCase)) { return "sha384"; }
+            if (string.Equals(oid.Value, Win32.szOID_RSA_SHA512RSA, StringComparison.OrdinalIgnoreCase)) { return "sha512"; }
+            return string.Empty;
+        }
+
+        internal static string GetHashAlgorithmUri(X509Certificate2 cert)
+        {
+            Oid oid = cert.SignatureAlgorithm;
+            if (string.Equals(oid.Value, Win32.szOID_RSA_SHA256RSA, StringComparison.OrdinalIgnoreCase)) { return ManifestSignatureUtility.Sha256SignatureMethodUri; }
+            if (string.Equals(oid.Value, Win32.szOID_RSA_SHA384RSA, StringComparison.OrdinalIgnoreCase)) { return ManifestSignatureUtility.Sha384SignatureMethodUri; }
+            if (string.Equals(oid.Value, Win32.szOID_RSA_SHA512RSA, StringComparison.OrdinalIgnoreCase)) { return ManifestSignatureUtility.Sha512SignatureMethodUri; }
+            return string.Empty;
+        }
+
+        internal static string GetDigestAlgorithmUri(X509Certificate2 cert)
+        {
+            Oid oid = cert.SignatureAlgorithm;
+            if (string.Equals(oid.Value, Win32.szOID_RSA_SHA256RSA, StringComparison.OrdinalIgnoreCase)) { return ManifestSignatureUtility.Sha256DigestMethod; }
+            if (string.Equals(oid.Value, Win32.szOID_RSA_SHA384RSA, StringComparison.OrdinalIgnoreCase)) { return ManifestSignatureUtility.Sha384DigestMethod; }
+            if (string.Equals(oid.Value, Win32.szOID_RSA_SHA512RSA, StringComparison.OrdinalIgnoreCase)) { return ManifestSignatureUtility.Sha512DigestMethod; }
+            return string.Empty;
+        }
+    }
+
     internal class ManifestSignedXml2 : SignedXml
     {
         private bool _verify = false;
-        private const string Sha256SignatureMethodUri = @"http://www.w3.org/2000/09/xmldsig#rsa-sha256";
-        private const string Sha256DigestMethod = @"http://www.w3.org/2000/09/xmldsig#sha256";
 
         internal ManifestSignedXml2()
             : base()
@@ -267,18 +341,30 @@ namespace System.Deployment.Internal.CodeSigning
         private void init()
         {
             CryptoConfig.AddAlgorithm(typeof(RSAPKCS1SHA256SignatureDescription),
-                               Sha256SignatureMethodUri);
+                               ManifestSignatureUtility.Sha256SignatureMethodUri);
+            CryptoConfig.AddAlgorithm(typeof(RSAPKCS1SHA384SignatureDescription),
+                               ManifestSignatureUtility.Sha384SignatureMethodUri);
+            CryptoConfig.AddAlgorithm(typeof(RSAPKCS1SHA512SignatureDescription),
+                               ManifestSignatureUtility.Sha512SignatureMethodUri);
 
 #if RUNTIME_TYPE_NETCORE
 #pragma warning disable SYSLIB0021 // Type or member is obsolete
             // SHA256 can not be used since it is an abstract class.
             // CalculateHashValue internally calls CryptoConfig.CreateFromName and it causes instantiation problems.
             CryptoConfig.AddAlgorithm(typeof(SHA256Managed),
-                               Sha256DigestMethod);
+                               ManifestSignatureUtility.Sha256DigestMethod);
+            CryptoConfig.AddAlgorithm(typeof(SHA384Managed),
+                               ManifestSignatureUtility.Sha384DigestMethod);
+            CryptoConfig.AddAlgorithm(typeof(SHA512Managed),
+                               ManifestSignatureUtility.Sha512DigestMethod);
 #pragma warning restore SYSLIB0021 // Type or member is obsolete
 #else
             CryptoConfig.AddAlgorithm(typeof(SHA256Cng),
-                               Sha256DigestMethod);
+                               ManifestSignatureUtility.Sha256DigestMethod);
+            CryptoConfig.AddAlgorithm(typeof(SHA384Cng),
+                               ManifestSignatureUtility.Sha384DigestMethod);
+            CryptoConfig.AddAlgorithm(typeof(SHA512Cng),
+                               ManifestSignatureUtility.Sha512DigestMethod);
 #endif
         }
 
@@ -306,19 +392,14 @@ namespace System.Deployment.Internal.CodeSigning
         private XmlDocument _manifestDom = null;
         private CmiStrongNameSignerInfo _strongNameSignerInfo = null;
         private CmiAuthenticodeSignerInfo _authenticodeSignerInfo = null;
-        private bool _useSha256;
-
-        private const string Sha256SignatureMethodUri = @"http://www.w3.org/2000/09/xmldsig#rsa-sha256";
-        private const string Sha256DigestMethod = @"http://www.w3.org/2000/09/xmldsig#sha256";
-        private const string Sha1SignatureMethodUri = @"http://www.w3.org/2000/09/xmldsig#rsa-sha1";
-        private const string Sha1DigestMethod = @"http://www.w3.org/2000/09/xmldsig#sha1";
+        private bool _useSha256OrHigher;
 
         private SignedCmiManifest2() { }
 
-        internal SignedCmiManifest2(XmlDocument manifestDom, bool useSha256)
+        internal SignedCmiManifest2(XmlDocument manifestDom, bool useSha256OrHigher)
         {
             _manifestDom = manifestDom ?? throw new ArgumentNullException(nameof(manifestDom));
-            _useSha256 = useSha256;
+            _useSha256OrHigher = useSha256OrHigher;
         }
 
         internal void Sign(CmiManifestSigner2 signer)
@@ -344,7 +425,7 @@ namespace System.Deployment.Internal.CodeSigning
             // Replace public key token in assemblyIdentity if requested.
             if ((signer.Flag & CmiManifestSignerFlag.DontReplacePublicKeyToken) == 0)
             {
-                ReplacePublicKeyToken(_manifestDom, signer.StrongNameKey, _useSha256);
+                ReplacePublicKeyToken(_manifestDom, signer.StrongNameKey, _useSha256OrHigher);
             }
 
             // No cert means don't Authenticode sign and timestamp.
@@ -356,10 +437,10 @@ namespace System.Deployment.Internal.CodeSigning
                 InsertPublisherIdentity(_manifestDom, signer.Certificate);
 
                 // Now create the license DOM, and then sign it.
-                licenseDom = CreateLicenseDom(signer, ExtractPrincipalFromManifest(), ComputeHashFromManifest(_manifestDom, _useSha256));
-                AuthenticodeSignLicenseDom(licenseDom, signer, timeStampUrl, _useSha256, disallowMansignTimestampFallback);
+                licenseDom = CreateLicenseDom(signer, ExtractPrincipalFromManifest(), ComputeHashFromManifest(_manifestDom, _useSha256OrHigher, signer.Certificate));
+                AuthenticodeSignLicenseDom(licenseDom, signer, timeStampUrl, _useSha256OrHigher, disallowMansignTimestampFallback);
             }
-            StrongNameSignManifestDom(_manifestDom, licenseDom, signer, _useSha256);
+            StrongNameSignManifestDom(_manifestDom, licenseDom, signer, _useSha256OrHigher);
         }
 
         internal CmiStrongNameSignerInfo StrongNameSignerInfo
@@ -460,12 +541,12 @@ namespace System.Deployment.Internal.CodeSigning
         /// As for official guidance – I’m not sure of any.    For workarounds though, if you’re using the Microsoft software CSPs, they share the underlying key store.  You can get the key container name from your RSA object, then open up a new RSA object with the same key container name but with PROV_RSA_AES.   At that point, you should be able to use SHA-2 algorithms.
         /// </summary>
         /// <param name="oldCsp"></param>
-        /// <param name="useSha256">Whether to use sha256</param>
+        /// <param name="useSha256OrHigher">Whether to use sha256 or better hash algorithms</param>
         /// <returns></returns>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Cryptographic.Standard", "CA5358:RSAProviderNeeds2048bitKey", Justification = "SHA1 is retained for compatibility reasons as an option in VisualStudio signing page and consequently in the trust manager, default is SHA2.")]
-        internal static RSACryptoServiceProvider GetFixedRSACryptoServiceProvider(RSACryptoServiceProvider oldCsp, bool useSha256)
+        internal static RSACryptoServiceProvider GetFixedRSACryptoServiceProvider(RSACryptoServiceProvider oldCsp, bool useSha256OrHigher)
         {
-            if (!useSha256)
+            if (!useSha256OrHigher)
             {
                 return oldCsp;
             }
@@ -477,7 +558,7 @@ namespace System.Deployment.Internal.CodeSigning
                 return oldCsp;
             }
 
-            const int PROV_RSA_AES = 24;    // CryptoApi provider type for an RSA provider supporting sha-256 digital signatures
+            const int PROV_RSA_AES = 24;    // CryptoApi provider type for an RSA provider supporting SHA-2 digital signatures
             CspParameters csp = new CspParameters();
             csp.ProviderType = PROV_RSA_AES;
             csp.KeyContainerName = oldCsp.CspKeyContainerInfo.KeyContainerName;
@@ -491,7 +572,7 @@ namespace System.Deployment.Internal.CodeSigning
             return fixedRsa;
         }
 
-        private static void ReplacePublicKeyToken(XmlDocument manifestDom, AsymmetricAlgorithm snKey, bool useSha256)
+        private static void ReplacePublicKeyToken(XmlDocument manifestDom, AsymmetricAlgorithm snKey, bool useSha256OrHigher)
         {
             // Make sure we can find the publicKeyToken attribute.
             XmlNamespaceManager nsm = new XmlNamespaceManager(manifestDom.NameTable);
@@ -511,7 +592,7 @@ namespace System.Deployment.Internal.CodeSigning
 
             if (snKey is RSACryptoServiceProvider rsacsp)
             {
-                using var cryptoProvider = GetFixedRSACryptoServiceProvider(rsacsp, useSha256);
+                using var cryptoProvider = GetFixedRSACryptoServiceProvider(rsacsp, useSha256OrHigher);
                 cspPublicKeyBlob = cryptoProvider.ExportCspBlob(false);
                 if (cspPublicKeyBlob == null || cspPublicKeyBlob.Length == 0)
                 {
@@ -551,7 +632,7 @@ namespace System.Deployment.Internal.CodeSigning
         }
 
         [SuppressMessage("Security", "CA5350:Do Not Use Weak Cryptographic Algorithms", Justification = "SHA1 is retained for compatibility reasons as an option in VisualStudio signing page and consequently in the trust manager, default is SHA2.")]
-        private static byte[] ComputeHashFromManifest(XmlDocument manifestDom, bool useSha256)
+        private static byte[] ComputeHashFromManifest(XmlDocument manifestDom, bool useSha256OrHigher, X509Certificate2 cert)
         {
             // Since the DOM given to us is not guaranteed to be normalized,
             // we need to normalize it ourselves. Also, we always preserve
@@ -573,23 +654,28 @@ namespace System.Deployment.Internal.CodeSigning
             XmlDsigExcC14NTransform exc = new XmlDsigExcC14NTransform();
             exc.LoadInput(normalizedDom);
 
-            if (useSha256)
+            if (useSha256OrHigher)
             {
-#pragma warning disable SA1111, SA1009 // Closing parenthesis should be on line of last parameter
-                using (SHA256 sha2 = SHA256.Create(
-#if FEATURE_CRYPTOGRAPHIC_FACTORY_ALGORITHM_NAMES
-                    "System.Security.Cryptography.SHA256CryptoServiceProvider"
-#endif
-                    ))
-#pragma warning restore SA1111, SA1009 // Closing parenthesis should be on line of last parameter
+                var algorithmFactory = ManifestSignatureUtility.GetHashAlgorithmFactory(cert);
+                if (algorithmFactory != null)
                 {
-                    byte[] hash = sha2.ComputeHash(exc.GetOutput() as MemoryStream);
-                    if (hash == null)
+#if FEATURE_CRYPTOGRAPHIC_FACTORY_ALGORITHM_NAMES
+                    using (var algorithm = algorithmFactory("System.Security.Cryptography.SHA256CryptoServiceProvider"))
+#else
+                    using (var algorithm = algorithmFactory())
+#endif                                        
                     {
-                        throw new CryptographicException(Win32.TRUST_E_BAD_DIGEST);
+                        byte[] hash = algorithm.ComputeHash(exc.GetOutput() as MemoryStream);
+                        if (hash == null)
+                        {
+                            throw new CryptographicException(Win32.TRUST_E_BAD_DIGEST);
+                        }
+                        return hash;
                     }
-
-                    return hash;
+                }
+                else
+                {
+                    throw new CryptographicException(Win32.CRYPT_E_UNKNOWN_ALGO);
                 }
             }
             else
@@ -599,9 +685,9 @@ namespace System.Deployment.Internal.CodeSigning
                 using (SHA1 sha1 = SHA1.Create(
 #if FEATURE_CRYPTOGRAPHIC_FACTORY_ALGORITHM_NAMES
                     "System.Security.Cryptography.SHA1CryptoServiceProvider"
-#endif
-                     ))
-#pragma warning restore SA1111, SA1009 // Closing parenthesis should be on line of last parameter
+#endif                    
+                ))
+#pragma warning restore SA1111, SA1009 // Closing parenthesis should be on line of last parameter                
                 {
                     byte[] hash = sha1.ComputeHash(exc.GetOutput() as MemoryStream);
                     if (hash == null)
@@ -659,7 +745,7 @@ namespace System.Deployment.Internal.CodeSigning
             return licenseDom;
         }
 
-        private static void AuthenticodeSignLicenseDom(XmlDocument licenseDom, CmiManifestSigner2 signer, string timeStampUrl, bool useSha256, bool disallowMansignTimestampFallback)
+        private static void AuthenticodeSignLicenseDom(XmlDocument licenseDom, CmiManifestSigner2 signer, string timeStampUrl, bool useSha256OrHigher, bool disallowMansignTimestampFallback)
         {
             // Make sure it is RSA, as this is the only one Fusion will support.
 #if RUNTIME_TYPE_NETCORE
@@ -676,16 +762,20 @@ namespace System.Deployment.Internal.CodeSigning
             ManifestSignedXml2 signedXml = new ManifestSignedXml2(licenseDom);
             // only needs to change the provider type when RSACryptoServiceProvider is used
             var rsaCsp = rsaPrivateKey is RSACryptoServiceProvider ?
-                            GetFixedRSACryptoServiceProvider(rsaPrivateKey as RSACryptoServiceProvider, useSha256) : rsaPrivateKey;
+                            GetFixedRSACryptoServiceProvider(rsaPrivateKey as RSACryptoServiceProvider, useSha256OrHigher) : rsaPrivateKey;
             signedXml.SigningKey = rsaCsp;
             signedXml.SignedInfo.CanonicalizationMethod = SignedXml.XmlDsigExcC14NTransformUrl;
-            if (signer.UseSha256)
+            if (signer.UseSha256OrHigher)
             {
-                    signedXml.SignedInfo.SignatureMethod = Sha256SignatureMethodUri;
+                signedXml.SignedInfo.SignatureMethod = ManifestSignatureUtility.GetHashAlgorithmUri(signer.Certificate);
+                if (string.IsNullOrEmpty(signedXml.SignedInfo.SignatureMethod))
+                {
+                    throw new CryptographicException(Win32.CRYPT_E_UNKNOWN_ALGO);
                 }
+            }
             else
             {
-                signedXml.SignedInfo.SignatureMethod = Sha1SignatureMethodUri;
+                signedXml.SignedInfo.SignatureMethod = ManifestSignatureUtility.Sha1SignatureMethodUri;
             }
 
             // Add the key information.
@@ -695,13 +785,17 @@ namespace System.Deployment.Internal.CodeSigning
             // Add the enveloped reference.
             Reference reference = new Reference();
             reference.Uri = "";
-            if (signer.UseSha256)
+            if (signer.UseSha256OrHigher)
             {
-                reference.DigestMethod = Sha256DigestMethod;
+                reference.DigestMethod = ManifestSignatureUtility.GetDigestAlgorithmUri(signer.Certificate);
+                if (string.IsNullOrEmpty(reference.DigestMethod))
+                {
+                    throw new CryptographicException(Win32.CRYPT_E_UNKNOWN_ALGO);
+                }
             }
             else
             {
-                reference.DigestMethod = Sha1DigestMethod;
+                reference.DigestMethod = ManifestSignatureUtility.Sha1DigestMethod;
             }
 
             // Add an enveloped and an Exc-C14N transform.
@@ -730,7 +824,7 @@ namespace System.Deployment.Internal.CodeSigning
             // Time stamp it if requested.
             if (!string.IsNullOrEmpty(timeStampUrl))
             {
-                TimestampSignedLicenseDom(licenseDom, timeStampUrl, useSha256, disallowMansignTimestampFallback);
+                TimestampSignedLicenseDom(licenseDom, timeStampUrl, useSha256OrHigher, disallowMansignTimestampFallback);
             }
 
             // Wrap it inside a RelData element.
@@ -744,12 +838,12 @@ namespace System.Deployment.Internal.CodeSigning
         //
         // This function is from mage.exe in .NET FX and is used to implement RFC 3161 timestamping.
         //
-        private static string ObtainRFC3161Timestamp(string timeStampUrl, string signatureValue, bool useSha256)
+        private static string ObtainRFC3161Timestamp(string timeStampUrl, string signatureValue, bool useSha256OrHigher)
         {
             byte[] sigValueBytes = Convert.FromBase64String(signatureValue);
             string timestamp = String.Empty;
 
-            string algId = useSha256 ? Win32.szOID_NIST_sha256 : Win32.szOID_OIWSEC_sha1;
+            string algId = useSha256OrHigher ? Win32.szOID_NIST_sha256 : Win32.szOID_OIWSEC_sha1;
 
             unsafe
             {
@@ -840,7 +934,7 @@ namespace System.Deployment.Internal.CodeSigning
             return timestamp;
         }
 
-        private static void TimestampSignedLicenseDom(XmlDocument licenseDom, string timeStampUrl, bool useSha256, bool disallowMansignTimestampFallback)
+        private static void TimestampSignedLicenseDom(XmlDocument licenseDom, string timeStampUrl, bool useSha256OrHigher, bool disallowMansignTimestampFallback)
         {
             XmlNamespaceManager nsm = new XmlNamespaceManager(licenseDom.NameTable);
             nsm.AddNamespace("r", LicenseNamespaceUri);
@@ -903,7 +997,7 @@ namespace System.Deployment.Internal.CodeSigning
             signatureNode.AppendChild(dsObject);
         }
 
-        private static void StrongNameSignManifestDom(XmlDocument manifestDom, XmlDocument licenseDom, CmiManifestSigner2 signer, bool useSha256)
+        private static void StrongNameSignManifestDom(XmlDocument manifestDom, XmlDocument licenseDom, CmiManifestSigner2 signer, bool useSha256OrHigher)
         {
             RSA snKey = signer.StrongNameKey as RSA;
 
@@ -933,20 +1027,24 @@ namespace System.Deployment.Internal.CodeSigning
             ManifestSignedXml2 signedXml = new ManifestSignedXml2(signatureParent);
             if (signer.StrongNameKey is RSACryptoServiceProvider rsacsp)
             {
-                signedXml.SigningKey = GetFixedRSACryptoServiceProvider(rsacsp, useSha256);
+                signedXml.SigningKey = GetFixedRSACryptoServiceProvider(rsacsp, useSha256OrHigher);
             }
             else
             {
                 signedXml.SigningKey = signer.StrongNameKey;
             }
             signedXml.SignedInfo.CanonicalizationMethod = SignedXml.XmlDsigExcC14NTransformUrl;
-            if (signer.UseSha256)
+            if (signer.UseSha256OrHigher)
             {
-                signedXml.SignedInfo.SignatureMethod = Sha256SignatureMethodUri;
+                signedXml.SignedInfo.SignatureMethod = ManifestSignatureUtility.GetHashAlgorithmUri(signer.Certificate);
+                if (string.IsNullOrEmpty(signedXml.SignedInfo.SignatureMethod))
+                {
+                    throw new CryptographicException(Win32.CRYPT_E_UNKNOWN_ALGO);
+                }
             }
             else
             {
-                signedXml.SignedInfo.SignatureMethod = Sha1SignatureMethodUri;
+                signedXml.SignedInfo.SignatureMethod = ManifestSignatureUtility.Sha1SignatureMethodUri;
             }
 
             // Add the key information.
@@ -960,13 +1058,17 @@ namespace System.Deployment.Internal.CodeSigning
             // Add the enveloped reference.
             Reference enveloped = new Reference();
             enveloped.Uri = "";
-            if (signer.UseSha256)
+            if (signer.UseSha256OrHigher)
             {
-                enveloped.DigestMethod = Sha256DigestMethod;
+                enveloped.DigestMethod = ManifestSignatureUtility.GetDigestAlgorithmUri(signer.Certificate);
+                if (string.IsNullOrEmpty(enveloped.DigestMethod))
+                {
+                    throw new CryptographicException(Win32.CRYPT_E_UNKNOWN_ALGO);
+                }
             }
             else
             {
-                enveloped.DigestMethod = Sha1DigestMethod;
+                enveloped.DigestMethod = ManifestSignatureUtility.Sha1DigestMethod;
             }
 
             // Add an enveloped then Exc-C14N transform.
@@ -1050,15 +1152,15 @@ namespace System.Deployment.Internal.CodeSigning
         private X509Certificate2Collection _certificates;
         private X509IncludeOption _includeOption;
         private CmiManifestSignerFlag _signerFlag;
-        private readonly bool _useSha256;
+        private readonly bool _useSha256OrHigher;
 
         private CmiManifestSigner2() { }
 
         internal CmiManifestSigner2(AsymmetricAlgorithm strongNameKey) :
-            this(strongNameKey, certificate: null, useSha256: false)
+            this(strongNameKey, certificate: null, useSha256OrHigher: false)
         { }
 
-        internal CmiManifestSigner2(AsymmetricAlgorithm strongNameKey, X509Certificate2 certificate, bool useSha256)
+        internal CmiManifestSigner2(AsymmetricAlgorithm strongNameKey, X509Certificate2 certificate, bool useSha256OrHigher)
         {
             if (strongNameKey == null)
             {
@@ -1077,14 +1179,14 @@ namespace System.Deployment.Internal.CodeSigning
             _certificates = new X509Certificate2Collection();
             _includeOption = X509IncludeOption.ExcludeRoot;
             _signerFlag = CmiManifestSignerFlag.None;
-            _useSha256 = useSha256;
+            _useSha256OrHigher = useSha256OrHigher;
         }
 
-        internal bool UseSha256
+        internal bool UseSha256OrHigher
         {
             get
             {
-                return _useSha256;
+                return _useSha256OrHigher;
             }
         }
 


### PR DESCRIPTION
### Context

The current behavior in ClickOnce is to allow certificates with SHA-256, SHA-384 and SHA-512 hash algorithms for signing but always default to SHA-256 for ClickOnce signing. There is expectation that customers will ask ClickOnce to support additional SHA-2 algorithms.

With this change, the new behavior will match the ClickOnce signing algorithm to the hash algorithm in the signing certificate. 

If the signing certificate's hash algorithm is not one of the above 3, ClickOnce will throw an error. 

We can discuss further if we should default to a algorithm instead of throwing an error.


### Changes made

The algorithm to use for ClickOnce signing has been plumbed through to the Manifest signing and PE signing code.

### Testing

CTI has tested privates of the MSBuild Tasks DLL with this change along with shgu's ClickOnce runtime changes to verify apps  signed with SHA-384 and SHA-512 install fine.
